### PR TITLE
Added NtOp class and a method to create an instance of it from String

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/fuel"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/swim/tree/Op.scala
+++ b/src/swim/tree/Op.scala
@@ -61,7 +61,7 @@ object Op {
         else if (isInt(s)) s.toInt
         else if (isDouble(s)) s.toDouble
         else if (isString(s)) s.substring(1, s.size-1)
-        else Symbol(s) // return a symbol, most probably this a variable.
+        else Symbol(s)
       else
         Symbol(s)
     }

--- a/src/swim/tree/Op.scala
+++ b/src/swim/tree/Op.scala
@@ -37,21 +37,16 @@ case class Op(val nt: Any, val op: Any, val args: Op*) extends Program {
 }
 
 
-/**
- * NtOp represents an untyped expression tree. This class is a subclass of Op class with
- * automatically assigned default type for convenience.
- */
-class NtOp(op: Any, args: Op*) extends Op('default, op, args:_*) {}
 
-
-object NtOp {
-  def apply(op: Any, args: Op*): NtOp = new NtOp(op, args:_*)
+object Op {
+  def apply(op: Any, args: Op*): Op = Op('default, op, args:_*)
   
   /**
-   * Constructs NtOp given it's string encoding in the form: OP(ARG1, ARG2, ...).
-   * For example from "+(-(a, b), c)" will be created NtOp("+", NtOp("-", NtOp("a"), NtOp("b")), NtOp("c")).
+   * Constructs Op given it's string encoding in the form: Op(ARG1, ARG2, ...).
+   * As nonterminal symbol assigned will be 'default.
+   * For example from "+(-(a, b), c)" will be created Op("+", Op("-", Op("a"), Op("b")), Op("c")).
    */
-  def fromStr(s: String): NtOp = {
+  def fromStr(s: String): Op = {
     def getStringOfFirstArg(s: String): (String, Int) = {
       val iComa = s.indexOf(",")
       val iPar = s.indexOf("(")
@@ -83,16 +78,16 @@ object NtOp {
     }
     try {
       val i = s.indexOf("(")
-      if (i == -1) NtOp(s)  // Returning terminal.
+      if (i == -1) Op(s)  // Returning terminal.
       else {
         val op = s.substring(0, i)
         val sargs = s.substring(i+1, s.size-1)
         val rawArgs = getRawArgs(sargs)
         val args = rawArgs.map{ a => fromStr(a.trim()) }
-        NtOp(op, args:_*)
+        Op(op, args:_*)
       }
     } catch {
-      case _ => throw new Exception("Wrong encoding of NtOp instance!")
+      case _ => throw new Exception("Wrong encoding of Op instance!")
     }
   }
 }

--- a/src/swim/tree/Op.scala
+++ b/src/swim/tree/Op.scala
@@ -54,7 +54,7 @@ object Op {
     def isBoolean(s: String): Boolean = if (s == "true" || s == "false") true else false
     def isInt(s: String): Boolean = try { val x = s.toInt; true } catch { case _ => false }
     def isDouble(s: String): Boolean = try { val x = s.toDouble; true } catch { case _ => false }
-    def isString(s: String): Boolean = if (s.last == '\"' && s.head == '\"') true else false
+    def isString(s: String): Boolean = if (s.head == '\"' && s.last == '\"') true else false
     def getTerminalOp(s: String): Any = {
       if (convertConsts)
         if (isBoolean(s)) s.toBoolean

--- a/src/swim/unittests/TestOp.scala
+++ b/src/swim/unittests/TestOp.scala
@@ -7,8 +7,8 @@ import swim.tree.NtOp
 
 final class TestOp {
   @Test def test_NtOp_fromStr_terminals() {
- 		assertEquals(NtOp("asd"), NtOp.fromStr("asd"))
- 		assertEquals(NtOp("5"), NtOp.fromStr("5"))
+    assertEquals(NtOp("asd"), NtOp.fromStr("asd"))
+    assertEquals(NtOp("5"), NtOp.fromStr("5"))
   }
   
   @Test def test_NtOp_fromStr_nonterminals_1() {
@@ -28,6 +28,6 @@ final class TestOp {
   
   @Test def test_NtOp_fromStr_nonterminals_4() {
     val op1 = NtOp.fromStr("+(a, --(b, *(c, d)))")
- 		assertEquals(NtOp("+", NtOp("a"), NtOp("--", NtOp("b"), NtOp("*", NtOp("c"), NtOp("d")))), op1)
+    assertEquals(NtOp("+", NtOp("a"), NtOp("--", NtOp("b"), NtOp("*", NtOp("c"), NtOp("d")))), op1)
   }
 }

--- a/src/swim/unittests/TestOp.scala
+++ b/src/swim/unittests/TestOp.scala
@@ -1,0 +1,33 @@
+package swim.unittests
+
+import org.junit.Test
+import org.junit.Assert._
+import swim.tree.Op
+import swim.tree.NtOp
+
+final class TestOp {
+  @Test def test_NtOp_fromStr_terminals() {
+ 		assertEquals(NtOp("asd"), NtOp.fromStr("asd"))
+ 		assertEquals(NtOp("5"), NtOp.fromStr("5"))
+  }
+  
+  @Test def test_NtOp_fromStr_nonterminals_1() {
+    val op1 = NtOp.fromStr("+(a, b)")
+    assertEquals(NtOp("+", NtOp("a"), NtOp("b")), op1)
+  }
+  
+  @Test def test_NtOp_fromStr_nonterminals_2() {
+    val op1 = NtOp.fromStr("+(-(a),*(b,c))")
+    assertEquals(NtOp("+", NtOp("-", NtOp("a")), NtOp("*", NtOp("b"), NtOp("c"))), op1)
+  }
+  
+  @Test def test_NtOp_fromStr_nonterminals_3() {
+    val op1 = NtOp.fromStr("+(-(*(ab, cd), ef), gh)")
+    assertEquals(NtOp("+", NtOp("-", NtOp("*", NtOp("ab"), NtOp("cd")), NtOp("ef")), NtOp("gh")), op1)
+  }
+  
+  @Test def test_NtOp_fromStr_nonterminals_4() {
+    val op1 = NtOp.fromStr("+(a, --(b, *(c, d)))")
+ 		assertEquals(NtOp("+", NtOp("a"), NtOp("--", NtOp("b"), NtOp("*", NtOp("c"), NtOp("d")))), op1)
+  }
+}

--- a/src/swim/unittests/TestOp.scala
+++ b/src/swim/unittests/TestOp.scala
@@ -3,31 +3,30 @@ package swim.unittests
 import org.junit.Test
 import org.junit.Assert._
 import swim.tree.Op
-import swim.tree.NtOp
 
 final class TestOp {
-  @Test def test_NtOp_fromStr_terminals() {
-    assertEquals(NtOp("asd"), NtOp.fromStr("asd"))
-    assertEquals(NtOp("5"), NtOp.fromStr("5"))
+  @Test def test_Op_fromStr_terminals() {
+    assertEquals(Op("asd"), Op.fromStr("asd"))
+    assertEquals(Op("5"), Op.fromStr("5"))
   }
   
-  @Test def test_NtOp_fromStr_nonterminals_1() {
-    val op1 = NtOp.fromStr("+(a, b)")
-    assertEquals(NtOp("+", NtOp("a"), NtOp("b")), op1)
+  @Test def test_Op_fromStr_nonterminals_1() {
+    val op1 = Op.fromStr("+(a, b)")
+    assertEquals(Op("+", Op("a"), Op("b")), op1)
   }
   
-  @Test def test_NtOp_fromStr_nonterminals_2() {
-    val op1 = NtOp.fromStr("+(-(a),*(b,c))")
-    assertEquals(NtOp("+", NtOp("-", NtOp("a")), NtOp("*", NtOp("b"), NtOp("c"))), op1)
+  @Test def test_Op_fromStr_nonterminals_2() {
+    val op1 = Op.fromStr("+(-(a),*(b,c))")
+    assertEquals(Op("+", Op("-", Op("a")), Op("*", Op("b"), Op("c"))), op1)
   }
   
-  @Test def test_NtOp_fromStr_nonterminals_3() {
-    val op1 = NtOp.fromStr("+(-(*(ab, cd), ef), gh)")
-    assertEquals(NtOp("+", NtOp("-", NtOp("*", NtOp("ab"), NtOp("cd")), NtOp("ef")), NtOp("gh")), op1)
+  @Test def test_Op_fromStr_nonterminals_3() {
+    val op1 = Op.fromStr("+(-(*(ab, cd), ef), gh)")
+    assertEquals(Op("+", Op("-", Op("*", Op("ab"), Op("cd")), Op("ef")), Op("gh")), op1)
   }
   
-  @Test def test_NtOp_fromStr_nonterminals_4() {
-    val op1 = NtOp.fromStr("+(a, --(b, *(c, d)))")
-    assertEquals(NtOp("+", NtOp("a"), NtOp("--", NtOp("b"), NtOp("*", NtOp("c"), NtOp("d")))), op1)
+  @Test def test_Op_fromStr_nonterminals_4() {
+    val op1 = Op.fromStr("+(a, --(b, *(c, d)))")
+    assertEquals(Op("+", Op("a"), Op("--", Op("b"), Op("*", Op("c"), Op("d")))), op1)
   }
 }

--- a/src/swim/unittests/TestOp.scala
+++ b/src/swim/unittests/TestOp.scala
@@ -6,27 +6,35 @@ import swim.tree.Op
 
 final class TestOp {
   @Test def test_Op_fromStr_terminals() {
-    assertEquals(Op("asd"), Op.fromStr("asd"))
-    assertEquals(Op("5"), Op.fromStr("5"))
+    assertEquals(Op('true), Op.fromStr("true", convertConsts=false))
+    assertEquals(Op(true), Op.fromStr("true", convertConsts=true))
+    assertEquals(Op(Symbol("5")), Op.fromStr("5", convertConsts=false))
+    assertEquals(Op(5), Op.fromStr("5", convertConsts=true))
+    assertEquals(Op(Symbol("5.1")), Op.fromStr("5.1", convertConsts=false))
+    assertEquals(Op(5.1), Op.fromStr("5.1", convertConsts=true))
+    assertEquals(Op(Symbol("\"as\"")), Op.fromStr("\"as\"", convertConsts=false))
+    assertEquals(Op("as"), Op.fromStr("\"as\"", convertConsts=true))
   }
   
   @Test def test_Op_fromStr_nonterminals_1() {
     val op1 = Op.fromStr("+(a, b)")
-    assertEquals(Op("+", Op("a"), Op("b")), op1)
+    assertEquals(Op('+, Op('a), Op('b)), op1)
   }
   
   @Test def test_Op_fromStr_nonterminals_2() {
     val op1 = Op.fromStr("+(-(a),*(b,c))")
-    assertEquals(Op("+", Op("-", Op("a")), Op("*", Op("b"), Op("c"))), op1)
+    assertEquals(Op('+, Op('-, Op('a)), Op('*, Op('b), Op('c))), op1)
   }
   
   @Test def test_Op_fromStr_nonterminals_3() {
     val op1 = Op.fromStr("+(-(*(ab, cd), ef), gh)")
-    assertEquals(Op("+", Op("-", Op("*", Op("ab"), Op("cd")), Op("ef")), Op("gh")), op1)
+    assertEquals(Op('+, Op('-, Op('*, Op('ab), Op('cd)), Op('ef)), Op('gh)), op1)
   }
   
   @Test def test_Op_fromStr_nonterminals_4() {
-    val op1 = Op.fromStr("+(a, --(b, *(c, d)))")
-    assertEquals(Op("+", Op("a"), Op("--", Op("b"), Op("*", Op("c"), Op("d")))), op1)
+    val opT = Op.fromStr("+(a, --(b, *(c, d)))", convertConsts=true)
+    val opF = Op.fromStr("+(a, --(b, *(c, d)))", convertConsts=false)
+    assertEquals(Op('+, Op('a), Op('--, Op('b), Op('*, Op('c), Op('d)))), opT)
+    assertEquals(opT, opF)
   }
 }


### PR DESCRIPTION
Op class forces user to explicitly supply nt (production symbol) attribute, which is inconvenient in some circumstances. To mitigate this, NtOp class is introduced with the 'default production symbol. Additionally, a directory for unit tests was created together with some tests for the method of creating NtOp from String.
