### PR TITLE
Fixed a bug in Op.fromStr method and added option to specify delimiter for arguments.

### DIFF
--- a/src/swim/tree/Op.scala
+++ b/src/swim/tree/Op.scala
@@ -49,11 +49,12 @@ object Op {
    * @param s string encoding of op.
    * @param convertConsts if set to true (default), terminals detected as Boolean, Int, Double or
    * String constants will be converted to instances of those types.
+   * @param delim delimiter which separates arguments of functions (default: " ").
    */
-  def fromStr(s: String, convertConsts: Boolean = true): Op = {
+  def fromStr(s: String, delim: String = " ", convertConsts: Boolean = true): Op = {
     def isBoolean(s: String): Boolean = if (s == "true" || s == "false") true else false
-    def isInt(s: String): Boolean = try { val x = s.toInt; true } catch { case _ => false }
-    def isDouble(s: String): Boolean = try { val x = s.toDouble; true } catch { case _ => false }
+    def isInt(s: String): Boolean = try { val x = s.toInt; true } catch { case _:Throwable => false }
+    def isDouble(s: String): Boolean = try { val x = s.toDouble; true } catch { case _:Throwable => false }
     def isString(s: String): Boolean = if (s.head == '\"' && s.last == '\"') true else false
     def getTerminalOp(s: String): Any = {
       if (convertConsts)
@@ -66,7 +67,7 @@ object Op {
         Symbol(s)
     }
     def getStringOfFirstArg(s: String): (String, Int) = {
-      val iComa = s.indexOf(",")
+      val iComa = s.indexOf(delim)
       val iPar = s.indexOf("(")
       if (iComa == -1) // This is a single terminal - return whole string.
         (s, s.size)
@@ -98,11 +99,11 @@ object Op {
       else {
         val op = s.substring(0, i)
         val sargs = s.substring(i+1, s.size-1)
-        val args = getRawArgs(sargs).map{ a => fromStr(a.trim()) }
+        val args = getRawArgs(sargs).map{ a => fromStr(a.trim(), delim, convertConsts) }
         Op(Symbol(op), args:_*)
       }
     } catch {
-      case _ => throw new Exception("Wrong encoding of Op instance!")
+      case _:Throwable => throw new Exception("Wrong encoding of Op instance!")
     }
   }
 }

--- a/src/swim/unittests/TestOp.scala
+++ b/src/swim/unittests/TestOp.scala
@@ -17,23 +17,27 @@ final class TestOp {
   }
   
   @Test def test_Op_fromStr_nonterminals_1() {
-    val op1 = Op.fromStr("+(a, b)")
+    val op1 = Op.fromStr("+(a b)")
     assertEquals(Op('+, Op('a), Op('b)), op1)
   }
   
   @Test def test_Op_fromStr_nonterminals_2() {
-    val op1 = Op.fromStr("+(-(a),*(b,c))")
+    val op1 = Op.fromStr("+(-(a), *(b, c))", ", ")
     assertEquals(Op('+, Op('-, Op('a)), Op('*, Op('b), Op('c))), op1)
+    val op2 = Op.fromStr("+(-(a),*(b,c))", ",")
+    assertEquals(Op('+, Op('-, Op('a)), Op('*, Op('b), Op('c))), op2)
+    val op3 = Op.fromStr("+(-(a) *(b c))", " ")
+    assertEquals(Op('+, Op('-, Op('a)), Op('*, Op('b), Op('c))), op3)
   }
   
   @Test def test_Op_fromStr_nonterminals_3() {
-    val op1 = Op.fromStr("+(-(*(ab, cd), ef), gh)")
+    val op1 = Op.fromStr("+(-(*(ab, cd), ef), gh)", delim = ", ")
     assertEquals(Op('+, Op('-, Op('*, Op('ab), Op('cd)), Op('ef)), Op('gh)), op1)
   }
   
   @Test def test_Op_fromStr_nonterminals_4() {
-    val opT = Op.fromStr("+(a, --(b, *(c, d)))", convertConsts=true)
-    val opF = Op.fromStr("+(a, --(b, *(c, d)))", convertConsts=false)
+    val opT = Op.fromStr("+(a, --(b, *(c, d)))", delim = ", ")
+    val opF = Op.fromStr("+(a, --(b, *(c, d)))", delim = ", ")
     assertEquals(Op('+, Op('a), Op('--, Op('b), Op('*, Op('c), Op('d)))), opT)
     assertEquals(opT, opF)
   }


### PR DESCRIPTION
This delimiter is also now by default set to ' ' so that it matches default delimiter used by Op's toString method.

Btw this perhaps is not obvious that fromStr method proves very useful while debugging. If your function doesn't work for a certain Op, then you can get it's text (either via debugger or value printed to stdout) and very quickly create Op instance for bug replication.
