### PR TITLE
Scaffold for regression examples.

### DIFF
--- a/src/swim/Test.scala
+++ b/src/swim/Test.scala
@@ -61,10 +61,12 @@ object Tests {
     case "1" => java.lang.Boolean.FALSE
     case "0" => java.lang.Boolean.TRUE
   }
+  def str2double(s: String) = s.toDouble
+  def str2int(s: String) = s.toInt
 
   def fromCSVfile[T](fname: String, conv: Function1[String, T] = toT _) = {
     val src = Source.fromFile(fname)
-    val lines = src.getLines().map(_.split(",|;|\t")).toList
+    val lines = src.getLines().map(_.split(",|;|\t|\\s+")).toList
     if (lines.map(_.size).toSet.size != 1)
       throw new Exception("Malformed CSV: Varying number of values per line")
     val res = lines.map(l => Test(l.dropRight(1).toList.map(conv(_)), conv(l.last))).toIndexedSeq

--- a/src/swim/app/ExamplesCSV.scala
+++ b/src/swim/app/ExamplesCSV.scala
@@ -38,4 +38,34 @@ object BooleanProblemFromCSV extends IApp(
   // launch the GP run
   RunExperiment(new SimpleGP(GPMoves(grammar, SimpleGP.defaultFeasible),
     eval, SimpleGP.correctDiscrete))
+  println("Finished")
+}
+
+
+object RegressionProblemFromCSV extends IApp(
+  'maxGenerations -> 20, 'populationSize -> 100,
+  'csvFile -> "regressionEx1.csv",
+  'parEval -> false // multithreaded evaluation off
+  ) {
+
+  val fname = opt.getOption("csvFile").get
+  val tests = Tests.fromCSVfile[Double](fname, Tests.str2double)
+  assume(tests.nonEmpty)
+
+  val numVars = tests(0).input.size
+  println("Number of input variables: " + numVars)
+  
+  // instruction set:
+  val instrSet = FloatingPointDomain.instructionSet(opt.paramString("instructions", "default")) +
+    (0 -> List(ConstantProviderUniformI(0, numVars - 1))) // input variables
+  val grammar = Grammar.fromSingleTypeInstructions(instrSet)
+
+  val domain = FloatingPointDomain(numVars)
+  // fitness function:
+  def eval(s: Op) = tests.count(t => domain(s)(t._1) != t._2)
+
+  // launch the GP run
+  RunExperiment(new SimpleGP(GPMoves(grammar, SimpleGP.defaultFeasible),
+    eval, SimpleGP.correctDiscrete))
+  println("Finished")
 }

--- a/src/swim/app/Regression.scala
+++ b/src/swim/app/Regression.scala
@@ -40,12 +40,9 @@ case class FloatingPointDomain(override val numVars: Int) extends DomainWithVars
   }
 }
 
-/* Typical instruction sets used in symbolic regression. 
- * 
- */
-object RegressionInstructionSets extends Function1[String, Map[Int, List[Symbol]]] {
+case object FloatingPointDomain {
   val arithm = List('+, '-, '*, '/)
-  def apply(name: String) = name match {
+  def instructionSet(name: String) = name match {
     case "default"     => Map(2 -> arithm)
     case "withTransc"  => Map(1 -> List('sin, 'cos, 'exp, 'lg, 'neg), 2 -> arithm)
     case "withNonTrig" => Map(1 -> List('sig, 'exp, 'lg, '-, 'n), 2 -> arithm)
@@ -70,7 +67,7 @@ case class RegressionBenchmark(implicit rng: TRandom) extends ProblemProvider[Se
       "nguy6" -> (1, g(-1, 1, 0.1).map(x => (Seq(x), math.sin(x) + math.sin(x * x + x)))),
       "nguy7" -> (1, g(0, 2, 0.1).map(x => (Seq(x), math.log(x + 1) + math.log(x * x + 1.0)))))
     val (v, gg) = bench(conf.paramString("benchmark"))
-    val instrSet = RegressionInstructionSets(conf.paramString("instructions", "default")) +
+    val instrSet = FloatingPointDomain.instructionSet(conf.paramString("instructions", "default")) +
       (0 -> List(ConstantProviderUniformI(0, v - 1))) // input variables
     (Grammar.fromSingleTypeInstructions(instrSet), FloatingPointDomain(v), Tests(gg.toIndexedSeq))
   }

--- a/src/swim/eval/Lexicase.scala
+++ b/src/swim/eval/Lexicase.scala
@@ -42,7 +42,7 @@ class LexicaseSelection[S, E](o: Ordering[E])(implicit rand: TRandom)
 
 /** EXPERIMENTAL
  *  TODO: E is dummy here; ideally, this should be rewritten without E whatsoever, 
- *  but this requires redefinition of Seleciton trait
+ *  but this requires redefinition of Selection trait
  */
 
 class LexicaseSelectionNoEval[S,E](o: Seq[Ordering[S]])(implicit rand: TRandom)


### PR DESCRIPTION
As in title. 

Some potential issues:
- constants may not be used,
- variables are represented in tree as integers, which leads to confusing output, especially so if constants were to be used.