### PR TITLE
Changed interfaces to collection.Seq; some small additions.

### DIFF
--- a/src/swim/Domain.scala
+++ b/src/swim/Domain.scala
@@ -1,7 +1,7 @@
 package swim
 
 import fuel.util.Options
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 
 /* Domain defines program semantics. 
  * Programs cannot be executed on their own; it is Domain that executes them. 

--- a/src/swim/Grammar.scala
+++ b/src/swim/Grammar.scala
@@ -5,7 +5,7 @@ import swim.tree.ConstantProviderUniformI
 import swim.tree.Op
 import swim.tree.CodeFactory
 import fuel.util.Random
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 
 /* Represents a single grammar production with a nonterminal nt. 
  * The right-hand side (RHS) r is a list of the following:

--- a/src/swim/Test.scala
+++ b/src/swim/Test.scala
@@ -1,6 +1,6 @@
 package swim
 
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 
 import fuel.util.CodeExecutor
 import scala.io.Source

--- a/src/swim/app/ArraySearch5.scala
+++ b/src/swim/app/ArraySearch5.scala
@@ -2,7 +2,7 @@ package swim.app
 
 import fuel.func.RunExperiment
 import fuel.util.IApp
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 import swim.tree.Op
 import swim.tree.ConstantProviderUniformI
 import swim.DomainWithVars
@@ -87,5 +87,5 @@ object ArraySearch5 extends IApp('maxGenerations -> 100) { // 'parEval -> false
     Test(y.:+(k), (pos + 1) % 5)
   }
 
-  RunExperiment(SimpleGP.Discrete(grammar, ArraySearch, tests))
+  RunExperiment(SimpleGP.Discrete(grammar, ArraySearch, tests.asInstanceOf[Seq[Test[Seq[Int], Int]]]))
 }

--- a/src/swim/app/Boolean.scala
+++ b/src/swim/app/Boolean.scala
@@ -2,7 +2,7 @@ package swim.app
 
 import fuel.util.TRandom
 import fuel.util.Options
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 import swim.ProblemProvider
 import swim.tree.ConstantProviderUniformI
 import swim.DomainWithVars

--- a/src/swim/app/Examples.scala
+++ b/src/swim/app/Examples.scala
@@ -10,7 +10,7 @@ import swim.tree.CodeFactory
 import swim.tree.Op
 import fuel.util.OptColl
 import swim.Tests
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 import swim.tree.GPMoves
 import swim.tree.LexicaseGP
 import swim.tree.IFSGP

--- a/src/swim/app/Regression.scala
+++ b/src/swim/app/Regression.scala
@@ -11,7 +11,7 @@ import swim.ProblemProvider
 import swim.Tests
 import swim.tree.ConstantProviderUniformI
 import swim.tree.Op
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 
 case class FloatingPointDomain(override val numVars: Int) extends DomainWithVars[Seq[Double], Double, Op](numVars) {
   override def semantics(input: Seq[Double]) = {

--- a/src/swim/app/String.scala
+++ b/src/swim/app/String.scala
@@ -1,6 +1,6 @@
 package swim.app
 
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 
 import fuel.func.RunExperiment
 import fuel.util.IApp

--- a/src/swim/eval/Lexicase.scala
+++ b/src/swim/eval/Lexicase.scala
@@ -1,5 +1,6 @@
 package swim.eval
 
+import scala.collection.Seq
 import scala.annotation.tailrec
 import fuel.util.TRandom
 import fuel.func.StochasticSelection

--- a/src/swim/tree/GP.scala
+++ b/src/swim/tree/GP.scala
@@ -18,7 +18,8 @@ import swim.Test
 import swim.Domain
 import swim.Grammar
 import swim.eval.IFSEval
-import scala.collection.immutable.Seq
+import scala.collection.Seq
+import fuel.func.BestSoFar
 
 /*
   * A class for realizing the workflow of the conventional 
@@ -105,6 +106,7 @@ object LexicaseGP {
   def correct = (_: Any, e: Seq[Int]) => e.forall(_ == 0)
 }
 
+
 class LexicaseGP[I, O](moves: Moves[Op], eval: Op => Seq[Int],
                        correct: (Op, Seq[Int]) => Boolean = LexicaseGP.correct)(
                          implicit opt: Options, coll: Collector, rng: TRandom)
@@ -113,6 +115,9 @@ class LexicaseGP[I, O](moves: Moves[Op], eval: Op => Seq[Int],
   val selection = new LexicaseSelection[Op, Int](Ordering[Int])
   override def iter = SimpleBreeder(selection, moves: _*) andThen evaluate
 
+  val bsf = BestSoFar[Op, Seq[Int]](MaxPassedOrdering, it)
+  override def report: Function1[StatePop[(Op, Seq[Int])], StatePop[(Op, Seq[Int])]] = bsf
+  
   val checkSuccess = (s: StatePop[(Op, Seq[Int])]) => {
     val cor = s.find(e => correct(e._1, e._2))
     coll.setResult("successRate", if (cor.isDefined) 1.0 else 0.0)
@@ -125,5 +130,13 @@ class LexicaseGP[I, O](moves: Moves[Op], eval: Op => Seq[Int],
 }
 
 
-
+// Assumptions: 0 - correct on test, 1 - incorrect.
+object MaxPassedOrdering extends Ordering[Seq[Int]] {
+  def compare(a:Seq[Int], b:Seq[Int]) = a.sum compare b.sum
+}
+// Assumptions: 0 - correct on test, 1 - incorrect.
+object LongerOrMaxPassedOrdering extends Ordering[Seq[Int]] {
+  def compare(a:Seq[Int], b:Seq[Int]) = if (a.size == b.size) a.sum compare b.sum
+                                        else b.size compare a.size // longer sequences are preffered
+}
 

--- a/src/swim/tree/GP.scala
+++ b/src/swim/tree/GP.scala
@@ -20,6 +20,7 @@ import swim.Grammar
 import swim.eval.IFSEval
 import scala.collection.Seq
 import fuel.func.BestSoFar
+import fuel.func.SequentialEval
 
 /*
   * A class for realizing the workflow of the conventional 
@@ -110,7 +111,9 @@ object LexicaseGP {
 class LexicaseGP[I, O](moves: Moves[Op], eval: Op => Seq[Int],
                        correct: (Op, Seq[Int]) => Boolean = LexicaseGP.correct)(
                          implicit opt: Options, coll: Collector, rng: TRandom)
-    extends EACore(moves, ParallelEval(eval), correct) {
+    extends EACore(moves,
+                   if (opt('parEval, true)) ParallelEval(eval) else SequentialEval(eval),
+                   correct) {
 
   val selection = new LexicaseSelection[Op, Int](Ordering[Int])
   override def iter = SimpleBreeder(selection, moves: _*) andThen evaluate

--- a/src/swim/tree/GPMoves.scala
+++ b/src/swim/tree/GPMoves.scala
@@ -6,7 +6,7 @@ import fuel.moves.Moves
 import fuel.func.SearchOperator
 import fuel.Preamble.RndApply
 import swim.Grammar
-import scala.collection.immutable.Seq
+import scala.collection.Seq
 
 /**
   * GPMoves provides the default set of GP operators.


### PR DESCRIPTION
I elaborated more on the Seq issue in the PR for fuel.

By simple renaming "import scala.collection.Seq" -> "import scala.collection.immutable.Seq" previous interface may be restored any time.